### PR TITLE
fixed typo

### DIFF
--- a/fitch.ott
+++ b/fitch.ott
@@ -37,11 +37,11 @@ grammar
 claim :: claim_ ::=
       {{ coq-universe Type }}
       {{ com claim }}
-      | judgment proof :: :: judgment_proof
+      | judgement proof :: :: judgement_proof
 
-judgment :: judgment_ ::=
+judgement :: judgement_ ::=
 	 {{ coq-universe Type }}
-	 {{ com judgment }}
+	 {{ com judgement }}
 	 | proplist |- prop :: :: follows
 
 prop {{ tex \phi }} :: prop_ ::=


### PR DESCRIPTION
Hmm. Not really a typo, but I thought judgement was the standard form. Now I see that it is perceived as a British form with an 'e'. So you adopt American English?